### PR TITLE
Sass compilation respects :ignored-files config

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -303,16 +303,16 @@
     (spit (str public blog-prefix "/" rss-name) (rss/make-channel config posts))
     (println (blue "compiling sass"))
     (sass/compile-sass->css!
-      (str "resources/templates/" sass-src)
-      (str "resources/public" blog-prefix "/" sass-dest))))
+     (str "resources/templates/" sass-src)
+     (str "resources/public" blog-prefix "/" sass-dest)
+     ignored-files)))
 
 (defn compile-assets-timed []
   (time
     (try
       (compile-assets)
       (catch Exception e
-        (if
-          (or (instance? IllegalArgumentException e)
-              (instance? clojure.lang.ExceptionInfo e))
+        (if (or (instance? IllegalArgumentException e)
+                (instance? clojure.lang.ExceptionInfo e))
           (println (red "Error:") (yellow (.getMessage e)))
           (write-exception e))))))

--- a/src/cryogen_core/io.clj
+++ b/src/cryogen_core/io.clj
@@ -5,11 +5,7 @@
 (def public "resources/public")
 
 (defn get-resource [resource]
-  (-> (Thread/currentThread)
-      (.getContextClassLoader)
-      (.getResource resource)
-      (.toURI)
-      (io/file)))
+  (-> resource io/resource io/file))
 
 (defn ignore [ignored-files]
   (fn [file]
@@ -37,10 +33,10 @@
   (doseq [asset (fs/find-files "resources/templates/md" #".+(jpg|jpeg|png|gif)")]
     (io/copy asset (io/file (str public blog-prefix "/img/" (.getName asset))))))
 
-(defn copy-resources [{:keys [blog-prefix resources]}]  
+(defn copy-resources [{:keys [blog-prefix resources]}]
   (doseq [resource resources]
     (let [src (str "resources/templates/" resource)
-          target (str public blog-prefix "/" resource)]      
+          target (str public blog-prefix "/" resource)]
       (cond
         (not (.exists (io/file src)))
         (throw (IllegalArgumentException. (str "resource " src " not found")))

--- a/src/cryogen_core/sass.clj
+++ b/src/cryogen_core/sass.clj
@@ -1,18 +1,27 @@
 (ns cryogen-core.sass
   (:require [clojure.java.shell :refer [sh]]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [cryogen-core.io :refer [ignore]]))
 
 (defn sass-installed?
   "Checks for the installation of Sass."
   []
   (= 0 (:exit (sh "sass" "--version"))))
 
+(defn re-filter [re]
+  (reify java.io.FilenameFilter
+    (accept [this _ name]
+      (not (nil? (re-find re name))))))
+
 (defn find-sass-files
-  "Given a Diretory, gets files, filtered to those having scss or sass extention"
-  [dir]
-  (->> (.list (io/file dir))
-       (seq)
-       (filter   (comp not nil?  (partial re-find #"(?i:s[ca]ss$)")))))
+  "Given a Diretory, gets files, Filtered to those having scss or sass
+  extention. Ignores files matching any ignored regexps."
+  [dir ignored-files]
+  (let [filename-filter (re-filter #"(?i:s[ca]ss$)")]
+    (->> (.listFiles (io/file dir) filename-filter)
+         (filter #(not (.isDirectory %)))
+         (filter (ignore ignored-files))
+         (map #(.getName %)))))
 
 (defn compile-sass-file!
   "Given a sass file which might be in src-sass directory,
@@ -31,8 +40,9 @@
 dest-sass. Prompts you to install sass if he finds sass files and can't find
 the command. Shows you any problems it comes across when compiling. "
   [src-sass
-   dest-sass]
-  (let [sass-files (find-sass-files src-sass)]
+   dest-sass
+   ignored-files]
+  (let [sass-files (find-sass-files src-sass ignored-files)]
     (if (seq sass-files)
       ;; I found sass files,
       ;; If sass is installed


### PR DESCRIPTION
This fixes an oversight from lacarmen/cryogen-core#4.

Also some slight refactoring of `get-resource`. FYI I concluded `.toURI` was redundant, let me know if there's a case I didn't consider.

This is completely separate from what I hope to do with checksum tracking (see #7).