### PR TITLE
Use checksums instead of last modified times.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,17 @@
-(defproject cryogen-core "0.1.10"
-            :description "Cryogen's compiler"
-            :url "https://github.com/lacarmen/cryogen-core"
-            :license {:name "Eclipse Public License"
-                      :url  "http://www.eclipse.org/legal/epl-v10.html"}
-            :dependencies [[org.clojure/clojure "1.6.0"]
-                           [clj-rss "0.1.9"]
-                           [me.raynes/fs "1.4.6"]
-                           [crouton "0.1.2"]
-                           [cheshire "5.4.0"]
-                           [clj-text-decoration "0.0.3"]
-                           [io.aviso/pretty "0.1.13"]
-                           [hiccup "1.0.5"]
-                           [selmer "0.7.8"]
-                           [markdown-clj "0.9.61"
-                            :exclusions [com.keminglabs/cljx]]])
+(defproject cryogen-core "0.1.11-SNAPSHOT"
+  :description "Cryogen's compiler"
+  :url "https://github.com/lacarmen/cryogen-core"
+  :license {:name "Eclipse Public License"
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [clj-rss "0.1.9"]
+                 [me.raynes/fs "1.4.6"]
+                 [crouton "0.1.2"]
+                 [cheshire "5.4.0"]
+                 [clj-text-decoration "0.0.3"]
+                 [io.aviso/pretty "0.1.13"]
+                 [hiccup "1.0.5"]
+                 [selmer "0.7.8"]
+                 [markdown-clj "0.9.61"
+                  :exclusions [com.keminglabs/cljx]]
+                 [pandect "0.4.1"]])


### PR DESCRIPTION
Also add pandect dependency.

It looks like switching to checksums for the watcher takes care of the double-compile problem I mentioned in #7 so no other fiddling should be necessary.